### PR TITLE
Remove PHP 5.3 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
   - hhvm
 install: composer install
 script: ./vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A PHP library for memoizing repeated function calls.
 [![License](http://img.shields.io/packagist/l/dominionenterprises/memoize.svg?style=flat)](https://packagist.org/packages/dominionenterprises/memoize)
 
 ## Requirements
-This library requires PHP 5.3, or newer.
+This library requires PHP 5.4, or newer.
 
 ## Installation
 This package uses [composer](https://getcomposer.org) so you can just add

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=5.3.2"
+        "php": "~5.4"
     },
     "require-dev": {
         "predis/predis": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d2ee7bf7e4ea17cc46df5e9ea83d0b7f",
+    "hash": "f61ea58b71b4225b77c0f4d2240f9a51",
     "packages": [],
     "packages-dev": [
         {
             "name": "ocramius/instantiator",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/Instantiator.git",
-                "reference": "cc754c2289ffd4483c319f6ed6ee88ce21676f64"
+                "reference": "8aa99efa86c51319afc26d23254fe6a8b5a5144a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/Instantiator/zipball/cc754c2289ffd4483c319f6ed6ee88ce21676f64",
-                "reference": "cc754c2289ffd4483c319f6ed6ee88ce21676f64",
+                "url": "https://api.github.com/repos/Ocramius/Instantiator/zipball/8aa99efa86c51319afc26d23254fe6a8b5a5144a",
+                "reference": "8aa99efa86c51319afc26d23254fe6a8b5a5144a",
                 "shasum": ""
             },
             "require": {
@@ -27,6 +27,7 @@
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpunit/phpunit": "~4.0",
                 "squizlabs/php_codesniffer": "2.0.*@ALPHA"
@@ -50,8 +51,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/",
-                    "role": "Developer"
+                    "homepage": "http://ocramius.github.com/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
@@ -60,7 +60,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2014-06-15 11:44:46"
+            "time": "2014-08-11 23:48:35"
         },
         {
             "name": "ocramius/lazy-map",
@@ -950,7 +950,7 @@
     "stability-flags": [],
     "prefer-stable": false,
     "platform": {
-        "php": ">=5.3.2"
+        "php": "~5.4"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
5.3 is now [EOL](http://php.net/archive/2014.php#id2014-08-14-1) and there is no reason for us to continue to support
this version from this moment on.  Users needing PHP 5.3 support can use
the previous version.
