### PR TITLE
Add expire TTL to secondary runtime key.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/src/Predis.php
+++ b/src/Predis.php
@@ -124,6 +124,7 @@ class Predis implements Memoize
 
             if ($cacheTime !== null) {
                 $this->client->expire($key, $cacheTime);
+                $this->client->expire("{$key}.runtime", $cacheTime);
             }
         } catch (\Exception $e) {
             // We don't want exceptions in accessing the cache to break functionality.

--- a/tests/PredisTest.php
+++ b/tests/PredisTest.php
@@ -96,7 +96,10 @@ class PredisTest extends TestCase
             [$this->equalTo($key), $this->equalTo($cachedValue)],
             [$this->equalTo("{$key}.runtime"), $this->lessThan(1)]
         );
-        $client->expects($this->once())->method('expire')->with($this->equalTo($key), $this->equalTo($cacheTime));
+        $client->expects($this->exactly(2))->method('expire')->withConsecutive(
+            [$this->equalTo($key), $this->equalTo($cacheTime)],
+            [$this->equalTo("{$key}.runtime"), $this->equalTo($cacheTime)]
+        );
 
         $memoizer = new Predis($client, false, 100);
 
@@ -128,7 +131,10 @@ class PredisTest extends TestCase
             [$this->equalTo($key), $this->equalTo($cachedValue)],
             [$this->equalTo("{$key}.runtime"), $this->lessThan(1)]
         );
-        $client->expects($this->once())->method('expire')->with($this->equalTo($key), $this->equalTo($cacheTime));
+        $client->expects($this->exactly(2))->method('expire')->withConsecutive(
+            [$this->equalTo($key), $this->equalTo($cacheTime)],
+            [$this->equalTo("{$key}.runtime"), $this->equalTo($cacheTime)]
+        );
 
         $memoizer = new Predis($client);
 


### PR DESCRIPTION
#### What does this PR do?
When TTL is provided for a key apply that same TTL to the secondary .runtime key created with it.
This prevents a problem where the secondary runtime keys are not removed even after the original key is.

#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

